### PR TITLE
add new relic agent to twint go env

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"twint-zero/Core"
 	"twint-zero/InputParser"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func main() {


### PR DESCRIPTION
New Relic requires an agent be imported in the Go project.